### PR TITLE
Web UI: improve restore message.

### DIFF
--- a/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_RestoreData.php
+++ b/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_RestoreData.php
@@ -8,6 +8,7 @@ $L['RestoreData_original'] = 'Restore data in the original path';
 $L['RestoreData_temp'] = 'Restore data in new directory';
 $L['RestoreData_String_restore'] = 'Select one or more directories or files to restore';
 $L['RestoreData_restore_message'] = 'Restored in ${0}';
+$L['RestoreData_restore_original_message'] = 'Restored in the original position';
 $L['path_label'] = 'Path';
 $L['RestoreData_file_restore'] = 'Directories or files to restore';
 $L['RestoreData_mode_restore'] = 'Restore mode';

--- a/root/usr/share/nethesis/NethServer/Module/RestoreData.php
+++ b/root/usr/share/nethesis/NethServer/Module/RestoreData.php
@@ -63,7 +63,11 @@ class RestoreData extends \Nethgui\Controller\AbstractController implements \Net
 
         if($this->getRequest()->isMutation()) {
             if(isset($this->restore_path)) {
-                $this->notifications->message($view->translate('RestoreData_restore_message', array($this->restore_path)));
+                if ($this->restore_path) {
+                    $this->notifications->message($view->translate('RestoreData_restore_message', array($this->restore_path)));
+                } else {
+                    $this->notifications->message($view->translate('RestoreData_restore_original_message'));
+                }
             }
         }
 


### PR DESCRIPTION
Previously, if a user tried to restore a directory (or file) in the original position, the notification said "Restored in ".

This commit, add a new special message displayed in the above scenario. New notification says "Restored in the original position".
