### PR TITLE
Rename module "Restore files"

### DIFF
--- a/root/usr/share/nethesis/NethServer/Help/en/NethServer_Module_RestoreData.rst
+++ b/root/usr/share/nethesis/NethServer/Help/en/NethServer_Module_RestoreData.rst
@@ -1,15 +1,15 @@
-============
-Restore Data
-============
+=============
+Restore files
+=============
 
-Restore data from backup through web interface.
+Restore files from backup through web interface.
 
 If you want to recover a file from an older backup, Select backup date from "Backup file" menu.
 
 Choose between two options:
 
-* restore data in the original path, the files are overwritten.
-* restore data in original path but with _DATE in the name, the files are not overwritten.
+* restore files in the original path, the files are overwritten.
+* restore files in original path but with _DATE in the name, the files are not overwritten.
 
 The restore steps are:
 
@@ -18,4 +18,4 @@ The restore steps are:
 * select directory to restore
 * press 'Restore'
 
-Note: Multiple selection can be done with Ctrl key pressed.
+Note: Multiple selection can be done with :guilabel:`Ctrl` key pressed.

--- a/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_RestoreData.php
+++ b/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_RestoreData.php
@@ -1,11 +1,12 @@
 <?php
 
 $L['RestoreData_Title'] = 'Restore data';
+$L['RestoreData_Title'] = 'Restore files';
 $L['RestoreData_label'] = 'Restore';
 $L['RestoreData_Description'] = 'Restore data from backup';
 $L['RestoreData_PlaceHolder'] = 'Search...';
-$L['RestoreData_original'] = 'Restore data in the original path';
-$L['RestoreData_temp'] = 'Restore data in new directory';
+$L['RestoreData_original'] = 'Restore files in the original path';
+$L['RestoreData_temp'] = 'Restore files in new directory';
 $L['RestoreData_String_restore'] = 'Select one or more directories or files to restore';
 $L['RestoreData_restore_message'] = 'Restored in ${0}';
 $L['RestoreData_restore_original_message'] = 'Restored in the original position';


### PR DESCRIPTION
The current "Restore data" name could be misleading. The module actually restores only files, whilst the restore-data CLI tool invokes also events that restore, for instance, MySQL DBs.

The admin manual should be changed accordingly.

http://docs.nethserver.org/en/v7rc/backup.html#graphic-interface